### PR TITLE
Retrieving the serialized bytes from a Julia FlatBuffer

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -49,6 +49,8 @@ val = Example.SimpleType(2) # create an instance of our type
 
 flatbuffer = FlatBuffers.build!(val) # start and build a flatbuffer for our SimpleType
 val2 = FlatBuffers.read(flatbuffer) # now we can deserialize the value from our flatbuffer, `val2` == `val`
+flatbytes = FlatBuffers.bytes(flatbuffer) # get the serialized bytes of the flatbuffer
+val3 = Flatbuffers.read(Example.SimpleType, flatbytes) # now we can deserialize directly from flatbytes
 ```
 
 For more involved examples, see the test suite [here](https://github.com/dmbates/FlatBuffers.jl/tree/master/test).

--- a/src/FlatBuffers.jl
+++ b/src/FlatBuffers.jl
@@ -237,6 +237,13 @@ FlatBuffers.read{T}(b::Builder{T}) = FlatBuffers.read(Table(T, b.bytes[b.head+1:
 # assume `bytes` is a pure flatbuffer buffer where we can read the root position at the beginning
 FlatBuffers.read{T}(::Type{T}, bytes) = FlatBuffers.read(T, bytes, read(IOBuffer(bytes), Int32))
 
+"""
+    flat_bytes = bytes(b)
+
+`flat_bytes` are the serialized bytes for the FlatBuffer.  This discards the Julia specific `head`.
+"""
+bytes(b::Builder) = unsafe_wrap(Array{UInt8,1}, pointer(b.bytes, b.head+1), (length(b.bytes)-b.head))
+
 function Builder{T}(::Type{T}=Any, size=0)
     objectend = 0
     vtables = zeros(Int, 0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,8 +29,10 @@ mon = Example.Monster(vec3, 150, 80, "MyMonster", false, collect(0x00:0x04),
         Bool[], 0, 0, 0)
 b = FlatBuffers.build!(mon)
 monst = FlatBuffers.read(b)
+monst2 = FlatBuffers.read(Example.Monster, FlatBuffers.bytes(b))
 
 @test mon.pos == monst.pos
+@test mon.pos == monst2.pos
 
 # create test types
 # types (Scalar, Enum, immutable, T, String, Vector{UInt8})


### PR DESCRIPTION
This is to try and address the confusion that I had in #20.  Now one can do:
```julia
...
x = Foo.Bar(1)
xbuilder = FlatBuffers.build!(x)

y = FlatBuffers.read(Foo.Bar, FlatBuffers.bytes(xbuilder))
...
```

I tried to run `docs/make.jl`, but it gave an error on my system.