### PR TITLE
Update to julia 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ os:
   - osx
 
 julia:
-  - 0.6
+  - 0.7
   - nightly
 
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.6
+julia 0.7-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,17 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 0.7
+  - julia_version: latest
+
+platform:
+  - x86
+  - x64
+
+## uncomment the following lines to allow failures on nightly julia
+## (tests will run but not make your overall status red)
+#matrix:
+#  allow_failures:
+#  - julia_version: latest
 
 branches:
   only:
@@ -17,24 +25,12 @@ notifications:
     on_build_status_changed: false
 
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# if there's a newer build queued for the same PR, cancel this one
-  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
-        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
-        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
-        throw "There are newer queued builds for this pull request, failing early." }
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/master/bin/install.ps1'))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo();
-      Pkg.clone(pwd(), \"FlatBuffers\"); Pkg.build(\"FlatBuffers\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia -e "Pkg.test(\"FlatBuffers\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - julia -e "%JL_TEST_SCRIPT%"

--- a/src/FlatBuffers.jl
+++ b/src/FlatBuffers.jl
@@ -1,17 +1,6 @@
 __precompile__(true)
 module FlatBuffers
 
-macro uninit(expr)
-    if !isdefined(Base, :uninitialized)
-        splice!(expr.args, 2)
-    end
-    return esc(expr)
-end
-
-if !isdefined(Base, :Nothing)
-    const Nothing = Void
-end
-
 # utils
 struct UndefinedType end
 const Undefined = UndefinedType()
@@ -152,7 +141,7 @@ end
 getarray(t, vp, len, ::Type{T}) where {T <: Scalar} = (ptr = convert(Ptr{T}, pointer(t.bytes, vp + 1)); return [unsafe_load(ptr, i) for i = 1:len])
 getarray(t, vp, len, ::Type{T}) where {T <: Enum} = (ptr = convert(Ptr{enumtype(T)}, pointer(t.bytes, vp + 1)); return [unsafe_load(ptr, i) for i = 1:len])
 function getarray(t, vp, len, ::Type{T}) where {T <: Union{AbstractString, Vector{UInt8}}}
-    A = @uninit Vector{T}(uninitialized, len)
+    A = Vector{T}(undef, len)
     for i = 1:len
         A[i] = getvalue(t, vp - t.pos, T)
         vp += sizeof(Int32)
@@ -164,7 +153,7 @@ function getarray(t, vp, len, ::Type{T}) where {T}
         ptr = convert(Ptr{T}, pointer(t.bytes, vp + 1))
         return [unsafe_load(ptr, i) for i = 1:len]
     else
-        A = @uninit Vector{T}(uninitialized, len)
+        A = Vector{T}(undef, len)
         for i = 1:len
             A[i] = getvalue(t, vp - t.pos, T)
             vp += sizeof(Int32)


### PR DESCRIPTION
Drops 0.6 support, and fixes the remaining deprecation warnings on 0.7.