### PR TITLE
remove cruft, get tests passing on 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,13 @@ os:
   - osx
 
 julia:
-  - 0.7
+  - 1.0
   - nightly
 
 notifications:
   email: false
 
 after_success:
-  - julia -e 'cd(Pkg.dir("FlatBuffers")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
-  - julia -e 'Pkg.add("Documenter")'
-  - julia -e 'cd(Pkg.dir("FlatBuffers")); include(joinpath("docs", "make.jl"))'
+  - julia -e 'using Pkg; cd(Pkg.dir("FlatBuffers")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
+  - julia -e 'using Pkg; Pkg.add("Documenter")'
+  - julia -e 'using Pkg; cd(Pkg.dir("FlatBuffers")); include(joinpath("docs", "make.jl"))'

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 | **Documentation**                                                               | **PackageEvaluator**                                            | **Build Status**                                                                                |
 |:-------------------------------------------------------------------------------:|:---------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------:|
-| [![][docs-stable-img]][docs-stable-url] [![][docs-latest-img]][docs-latest-url] | [![][pkg-0.4-img]][pkg-0.4-url] [![][pkg-0.5-img]][pkg-0.5-url] | [![][travis-img]][travis-url] [![][appveyor-img]][appveyor-url] [![][codecov-img]][codecov-url] |
+| [![][docs-stable-img]][docs-stable-url] [![][docs-latest-img]][docs-latest-url] | [![][pkg-0.6-img]][pkg-0.6-url] [![][pkg-0.7-img]][pkg-0.7-url] | [![][travis-img]][travis-url] [![][appveyor-img]][appveyor-url] [![][codecov-img]][codecov-url] |
 
 
 ## Installation
@@ -23,7 +23,7 @@ julia> Pkg.add("FlatBuffers")
 
 ## Project Status
 
-The package is tested against Julia `0.4` and *current* `0.5-dev` on Linux, OS X, and Windows.
+The package is tested against Julia `1.0` and nightly on Linux, OS X, and Windows.
 
 ## Contributing and Questions
 
@@ -49,7 +49,7 @@ Contributions are very welcome, as are feature requests and suggestions. Please 
 
 [issues-url]: https://github.com/JuliaData/FlatBuffers.jl/issues
 
-[pkg-0.4-img]: http://pkg.julialang.org/badges/FlatBuffers_0.4.svg
-[pkg-0.4-url]: http://pkg.julialang.org/?pkg=FlatBuffers
-[pkg-0.5-img]: http://pkg.julialang.org/badges/FlatBuffers_0.5.svg
-[pkg-0.5-url]: http://pkg.julialang.org/?pkg=FlatBuffers
+[pkg-0.6-img]: https://pkg.julialang.org/badges/FlatBuffers_0.6.svg
+[pkg-0.6-url]: https://pkg.julialang.org/?pkg=FlatBuffers
+[pkg-0.7-img]: https://pkg.julialang.org/badges/FlatBuffers_0.7.svg
+[pkg-0.7-url]: https://pkg.julialang.org/?pkg=FlatBuffers

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.7-
+julia 0.7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   matrix:
-  - julia_version: 0.7
+  - julia_version: 1.0
   - julia_version: latest
 
 platform:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,17 +1,17 @@
 environment:
   matrix:
   - julia_version: 1.0
-  - julia_version: latest
+  - julia_version: nightly
 
 platform:
-  - x86
-  - x64
+  - x86 # 32-bit
+  - x64 # 64-bit
 
-## uncomment the following lines to allow failures on nightly julia
-## (tests will run but not make your overall status red)
-#matrix:
-#  allow_failures:
-#  - julia_version: latest
+# # Uncomment the following lines to allow failures on nightly julia
+# # (tests will run but not make your overall status red)
+# matrix:
+#   allow_failures:
+#   - julia_version: nightly
 
 branches:
   only:
@@ -25,12 +25,18 @@ notifications:
     on_build_status_changed: false
 
 install:
-  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/master/bin/install.ps1'))
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
   - echo "%JL_BUILD_SCRIPT%"
-  - julia -e "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
   - echo "%JL_TEST_SCRIPT%"
-  - julia -e "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+# # Uncomment to support code coverage upload. Should only be enabled for packages
+# # which would have coverage gaps without running on Windows
+# on_success:
+#   - echo "%JL_CODECOV_SCRIPT%"
+#   - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -68,4 +68,4 @@ List of types/methods:
 * `@ALIGN T size_in_bytes`: convenience macro for forcing a flatbuffer alignment on the Julia type `T` to `size_in_bytes`
 * `@DEFAULT T field1=val1 field2=val2 ...`: convenience macro for defining default field values for Julia type `T`
 * `@UNION T Union{T1,T2,...}`: convenience macro for defining a flatbuffer union type `T`
-* `@STRUCT immutable T fields... end`: convenience macro for defining flatbuffer struct types, ensuring any necessary padding gets added to the type definition
+* `@STRUCT struct T fields... end`: convenience macro for defining flatbuffer struct types, ensuring any necessary padding gets added to the type definition

--- a/src/FlatBuffers.jl
+++ b/src/FlatBuffers.jl
@@ -16,13 +16,7 @@ const Scalar = Union{UndefinedType, Bool,
                         UInt8, UInt16, UInt32, UInt64,
                         Float32, Float64}
 
-if VERSION < v"0.7-DEV"
-    isconcrete = isleaftype
-else
-    isconcrete = isconcretetype
-end
-
-isstruct(T) = !T.mutable && isconcrete(T)
+isstruct(T) = !T.mutable && isconcretetype(T)
 isbitstype(T) = fieldcount(T) == 0
 
 default(T, TT, sym) = default(TT)

--- a/src/internals.jl
+++ b/src/internals.jl
@@ -190,13 +190,6 @@ function endvector(b::Builder, vectorNumElems)
     return offset(b)
 end
 
-if !isdefined(Base, :codeunits)
-	codeunits = Vector{UInt8}
-end
-if !isdefined(Base, :copyto!)
-	copyto! = copy!
-end
-
 """
 `createstring` writes a null-terminated string as a vector.
 """

--- a/test/internals.jl
+++ b/test/internals.jl
@@ -672,7 +672,7 @@ mutable struct LCG
     LCG() = new(UInt32(InitialLCGSeed))
 end
 reset!(lcg::LCG) = lcg.val = UInt32(InitialLCGSeed)
-function Base.next(lcg::LCG)
+function next(lcg::LCG)
     n = UInt32((UInt64(lcg.val) * UInt64(279470273)) % UInt64(4294967291))
     lcg.val = n
     return n

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,5 @@
 using FlatBuffers
-@static if VERSION < v"0.7.0-DEV.2005"
-    using Base.Test
-else
-    using Test
-end
-if !isdefined(Base, :Nothing)
-    const Nothing = Void
-end
+using Test
 
 include("internals.jl")
 CheckByteLayout()


### PR DESCRIPTION
Please have a good look at the change in `macros.jl`, because I don't fully get what is happening there, and why this works. I would think `__module__` needs to be replaced by `@__MODULE__`, but this breaks the tests.