### PR TITLE
fixing compatibility with Julia 1.7.

### DIFF
--- a/src/FlatBuffers.jl
+++ b/src/FlatBuffers.jl
@@ -31,7 +31,12 @@ Int8, Int16, Int32, Int64,
 UInt8, UInt16, UInt32, UInt64,
 Float32, Float64}
 
-isstruct(T) = isconcretetype(T) && !ismutabletype(T)
+if VERSION >= v"1.7.0-beta"
+	isstruct(T) = isconcretetype(T) && !ismutabletype(T)
+else
+	isstruct(T) = isconcretetype(T) && !T.mutable
+end
+
 isbitstype(T) = fieldcount(T) == 0
 isunionwithnothing(T) = T isa Union && T.a == Nothing && !(isa(T.b, Union))
 


### PR DESCRIPTION
Sorry for the fuss, have to fix the fix (previous commit), not working for Julia < 1.7.
ismutabletype() is actually new in 1.7.