### PR TITLE
fix version bounds for `ismutabletype`

### DIFF
--- a/src/FlatBuffers.jl
+++ b/src/FlatBuffers.jl
@@ -31,7 +31,7 @@ Int8, Int16, Int32, Int64,
 UInt8, UInt16, UInt32, UInt64,
 Float32, Float64}
 
-if VERSION >= v"1.7.0-beta"
+if VERSION >= v"1.7.0-DEV.204"
 	isstruct(T) = isconcretetype(T) && !ismutabletype(T)
 else
 	isstruct(T) = isconcretetype(T) && !T.mutable


### PR DESCRIPTION
The version bound actually doesn't catch the 1.7 RC versions.