### PR TITLE
avoid making globals with eval 

### DIFF
--- a/src/FlatBuffers.jl
+++ b/src/FlatBuffers.jl
@@ -313,8 +313,8 @@ function FlatBuffers.read(t::Table{T1}, ::Type{T}=T1) where {T1, T}
             push!(args, nullable ? nothing : default(T, TT, T.name.names[i]))
         else
             if isunionvector
-                eval(:(newr = getvalue($t, $o, $R)))
-                eval(:(n = length($R.types)))
+                newr = getvalue(eval(t), eval(o), eval(R))
+                n = length(eval(R)).types
                 push!(args, [getfieldvalue(newr, j) for j = 1:n]) 
             else
                 push!(args, getvalue(t, o, R))
@@ -422,7 +422,7 @@ end
 # and populate them with values from the vector
 function createstruct(types::Vector{DataType}, A::Vector{T}) where {T}
 	T1 = definestruct(types)
-	eval(:(newt = $T1($(A...))))
+	newt = eval(T1)(A...)
 	return newt
 end
 

--- a/src/FlatBuffers.jl
+++ b/src/FlatBuffers.jl
@@ -314,7 +314,7 @@ function FlatBuffers.read(t::Table{T1}, ::Type{T}=T1) where {T1, T}
         else
             if isunionvector
                 R = eval(R)
-                newr = invokelatest(getvalue, t, o, R)
+                newr = Base.invokelatest(getvalue, t, o, R)
                 n = length(R.types)
                 push!(args, [getfieldvalue(newr, j) for j = 1:n]) 
             else
@@ -423,7 +423,7 @@ end
 # and populate them with values from the vector
 function createstruct(types::Vector{DataType}, A::Vector{T}) where {T}
 	T1 = definestruct(types)
-	newt = invokelatest(eval(T1), A...)
+	newt = Base.invokelatest(eval(T1), A...)
 	return newt
 end
 

--- a/src/FlatBuffers.jl
+++ b/src/FlatBuffers.jl
@@ -314,7 +314,7 @@ function FlatBuffers.read(t::Table{T1}, ::Type{T}=T1) where {T1, T}
         else
             if isunionvector
                 R = eval(R)
-                newr = getvalue(t, o, R)
+                newr = invokelatest(getvalue, t, o, R)
                 n = length(R.types)
                 push!(args, [getfieldvalue(newr, j) for j = 1:n]) 
             else
@@ -423,7 +423,7 @@ end
 # and populate them with values from the vector
 function createstruct(types::Vector{DataType}, A::Vector{T}) where {T}
 	T1 = definestruct(types)
-	newt = eval(T1)(A...)
+	newt = invokelatest(eval(T1), A...)
 	return newt
 end
 

--- a/src/FlatBuffers.jl
+++ b/src/FlatBuffers.jl
@@ -313,8 +313,9 @@ function FlatBuffers.read(t::Table{T1}, ::Type{T}=T1) where {T1, T}
             push!(args, nullable ? nothing : default(T, TT, T.name.names[i]))
         else
             if isunionvector
-                newr = getvalue(eval(t), eval(o), eval(R))
-                n = length(eval(R)).types
+                R = eval(R)
+                newr = getvalue(t, o, R)
+                n = length(R.types)
                 push!(args, [getfieldvalue(newr, j) for j = 1:n]) 
             else
                 push!(args, getvalue(t, o, R))


### PR DESCRIPTION
Sort of a fix on various levels, since relying on a lot of global side-effects here seems quite odd and not intended. Mostly just to keep this working in v1.12 though, where this code becomes detected as broken.

From PkgEval https://github.com/JuliaLang/julia/issues/57328#issuecomment-2648495769