### PR TITLE
Use NamedTuple to avoid definestruct problems?

### DIFF
--- a/src/FlatBuffers.jl
+++ b/src/FlatBuffers.jl
@@ -313,8 +313,7 @@ function FlatBuffers.read(t::Table{T1}, ::Type{T}=T1) where {T1, T}
             push!(args, nullable ? nothing : default(T, TT, T.name.names[i]))
         else
             if isunionvector
-                R = eval(R)
-                newr = Base.invokelatest(getvalue, t, o, R)
+                newr = getvalue(t, o, R)
                 n = length(R.types)
                 push!(args, [getfieldvalue(newr, j) for j = 1:n]) 
             else
@@ -411,20 +410,14 @@ end
 
 # make a new struct which has fields of the given type
 function definestruct(types::Vector{DataType})
-	fields = [:($(gensym())::$(TT)) for TT in types]
-	T1 = gensym()
-	eval(:(mutable struct $T1
-		$(fields...)
-	end))
-	return T1
+	names = [Symbol(:_, i) for i in 1:length(types)]
+	return NamedTuple{tuple(names...), Tuple{types...}}
 end
 
 # make a new struct which has fields of the given type
 # and populate them with values from the vector
 function createstruct(types::Vector{DataType}, A::Vector{T}) where {T}
-	T1 = definestruct(types)
-	newt = Base.invokelatest(eval(T1), A...)
-	return newt
+	return T1(A...)
 end
 
 # struct or table/object vector

--- a/src/FlatBuffers.jl
+++ b/src/FlatBuffers.jl
@@ -313,8 +313,8 @@ function FlatBuffers.read(t::Table{T1}, ::Type{T}=T1) where {T1, T}
             push!(args, nullable ? nothing : default(T, TT, T.name.names[i]))
         else
             if isunionvector
-                eval(:(newr = getvalue($t, $o, $R)))
-                eval(:(n = length($R.types)))
+                newr = getvalue(eval(t), eval(o), eval(R))
+                n = length(eval(R)).types
                 push!(args, [getfieldvalue(newr, j) for j = 1:n]) 
             else
                 push!(args, getvalue(t, o, R))
@@ -422,7 +422,7 @@ end
 # and populate them with values from the vector
 function createstruct(types::Vector{DataType}, A::Vector{T}) where {T}
 	T1 = definestruct(types)
-	eval(:(newt = $T1($(A...))))
+	newt = eval(T1)(A...)
 	return newt
 end
 

--- a/src/FlatBuffers.jl
+++ b/src/FlatBuffers.jl
@@ -259,7 +259,7 @@ function getvalue(t, o, ::Type{T}) where {T}
 				push!(args, val)
 				o += sizeof(typ <: Enum ? enumtype(typ) : typ)
 			end
-			return T(args)
+			return T <: NamedTuple ? T(args) : T(args...)
 		else
 			return unsafe_load(convert(Ptr{T}, pointer(view(t.bytes, (t.pos + o + 1):length(t.bytes)))))
 		end

--- a/src/FlatBuffers.jl
+++ b/src/FlatBuffers.jl
@@ -314,7 +314,7 @@ function FlatBuffers.read(t::Table{T1}, ::Type{T}=T1) where {T1, T}
         else
             if isunionvector
                 R = eval(R)
-                newr = invokelatest(getvalue, t, o, R)
+                newr = Base.invokelatest(getvalue, t, o, R)
                 n = length(R.types)
                 push!(args, [getfieldvalue(newr, j) for j = 1:n]) 
             else
@@ -423,7 +423,7 @@ end
 # and populate them with values from the vector
 function createstruct(types::Vector{DataType}, A::Vector{T}) where {T}
 	T1 = definestruct(types)
-	newt = invokelatest(eval(T1), A...)
+	newt = Base.invokelatest(eval(T1), A...)
 	return newt
 end
 

--- a/src/FlatBuffers.jl
+++ b/src/FlatBuffers.jl
@@ -314,7 +314,7 @@ function FlatBuffers.read(t::Table{T1}, ::Type{T}=T1) where {T1, T}
         else
             if isunionvector
                 R = eval(R)
-                newr = getvalue(t, o, R)
+                newr = invokelatest(getvalue, t, o, R)
                 n = length(R.types)
                 push!(args, [getfieldvalue(newr, j) for j = 1:n]) 
             else
@@ -423,7 +423,7 @@ end
 # and populate them with values from the vector
 function createstruct(types::Vector{DataType}, A::Vector{T}) where {T}
 	T1 = definestruct(types)
-	newt = eval(T1)(A...)
+	newt = invokelatest(eval(T1), A...)
 	return newt
 end
 

--- a/src/FlatBuffers.jl
+++ b/src/FlatBuffers.jl
@@ -313,8 +313,9 @@ function FlatBuffers.read(t::Table{T1}, ::Type{T}=T1) where {T1, T}
             push!(args, nullable ? nothing : default(T, TT, T.name.names[i]))
         else
             if isunionvector
-                newr = getvalue(eval(t), eval(o), eval(R))
-                n = length(eval(R)).types
+                R = eval(R)
+                newr = getvalue(t, o, R)
+                n = length(R.types)
                 push!(args, [getfieldvalue(newr, j) for j = 1:n]) 
             else
                 push!(args, getvalue(t, o, R))

--- a/src/FlatBuffers.jl
+++ b/src/FlatBuffers.jl
@@ -259,7 +259,7 @@ function getvalue(t, o, ::Type{T}) where {T}
 				push!(args, val)
 				o += sizeof(typ <: Enum ? enumtype(typ) : typ)
 			end
-			return T(args...)
+			return T(args)
 		else
 			return unsafe_load(convert(Ptr{T}, pointer(view(t.bytes, (t.pos + o + 1):length(t.bytes)))))
 		end
@@ -417,7 +417,7 @@ end
 # make a new struct which has fields of the given type
 # and populate them with values from the vector
 function createstruct(types::Vector{DataType}, A::Vector{T}) where {T}
-	return T1(A...)
+	return definestruct(types)(A)
 end
 
 # struct or table/object vector


### PR DESCRIPTION
PR against https://github.com/JuliaData/FlatBuffers.jl/pull/65 to attempt making the code a bit simpler and avoid many problems (using NamedTuple instead of gensym). Though this code previously makes the assumption that structs are guaranteed to have the default constructor or are an AbstractArray, while NamedTuple does not have that.