### PR TITLE
Remove outdated assets keyword to makedocs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,7 +8,6 @@ makedocs(;
     ],
     repo="https://github.com/JuliaData/FlatBuffers.jl/blob/{commit}{path}#L{line}",
     sitename="FlatBuffers.jl",
-    assets=String[],
 )
 
 deploydocs(;

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,7 +6,7 @@ makedocs(;
     pages=[
         "Home" => "index.md",
     ],
-    repo=GitHub("JuliaData", "FlatBuffers.jl"),
+    repo=Documenter.Remotes.GitHub("JuliaData", "FlatBuffers.jl"),
     sitename="FlatBuffers.jl",
 )
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,6 +12,5 @@ makedocs(;
 
 deploydocs(;
     repo="github.com/JuliaData/FlatBuffers.jl",
-    devbranch = "main",
-    push_preview = true
+    devbranch = "main"
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,11 +6,12 @@ makedocs(;
     pages=[
         "Home" => "index.md",
     ],
-    repo="https://github.com/JuliaData/FlatBuffers.jl/blob/{commit}{path}#L{line}",
+    repo=GitHub("JuliaData", "FlatBuffers.jl"),
     sitename="FlatBuffers.jl",
 )
 
 deploydocs(;
     repo="github.com/JuliaData/FlatBuffers.jl",
-    devbranch = "main"
+    devbranch = "main",
+    push_preview = true
 )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -86,3 +86,15 @@ internal methods and may be queried using `?` at the REPL.
 * `@UNION T Union{T1,T2,...}` - convenience macro for defining a flatbuffer union type `T`
 * `@STRUCT struct T fields... end` - convenience macro for defining flatbuffer struct types, ensuring any necessary padding gets added to the type definition
 
+## API
+
+```@autodocs
+Modules = [FlatBuffers]
+```
+
+### Base extensions
+
+```@doc
+Base.read
+Base.prepend!
+```


### PR DESCRIPTION
* Remove the outdated `assets` keyword
* Update the `repo` keyword to use `Documenter.Remotes.Github`
* Add all docstrings

Not done:
* Enable `push_preview`. The `DOCUMENTER_KEY` secret needs to be installed